### PR TITLE
Update testbed for viewer v1.0.866: new stubs, bug fixes, cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <title>Tandem TestBed (JavaScript SDK)</title>
     
     <!-- Tandem Viewer -->
-    <script src="https://static.tandem.autodesk.com/1.0.829/viewer3D.js"></script>
-    <link href="https://static.tandem.autodesk.com/1.0.829/style.min.css" rel="stylesheet" type="text/css">
+    <script src="https://static.tandem.autodesk.com/1.0.866/viewer3D.js"></script>
+    <link href="https://static.tandem.autodesk.com/1.0.866/style.min.css" rel="stylesheet" type="text/css">
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/js/stubs/documentStubs.js
+++ b/js/stubs/documentStubs.js
@@ -55,6 +55,14 @@ export async function deleteDocument(docURN) {
 
     console.group('STUB: deleteDocument()');
 
+    // deleteDocument() requires ALManage access level on the server side -
+    // calling it with lower access returns 403 Forbidden.
+    if (!facility.canManage()) {
+        console.log('(skipped - requires Manage or Owner access level)');
+        console.groupEnd();
+        return;
+    }
+
     await facility.deleteDocument(docURN);
     console.log('Document deleted');
 

--- a/js/stubs/streamStubs.js
+++ b/js/stubs/streamStubs.js
@@ -214,9 +214,18 @@ export async function getAttributeCandidates() {
 export async function getStreamSecrets(streamKeys) {
     console.group('STUB: getStreamSecrets()');
 
+    const facility = getCurrentFacility();
+    // getStreamSecret() requires ALManage access level on the server side -
+    // calling it with lower access returns 403 Forbidden.
+    if (!facility?.canManage()) {
+        console.log('(skipped - requires Manage or Owner access level)');
+        console.groupEnd();
+        return;
+    }
+
     const streamKeysArray = streamKeys.split(',').map(k => k.trim());
 
-    const strmMgr = getCurrentFacility()?.getStreamManager();
+    const strmMgr = facility.getStreamManager();
     if (strmMgr) {
         const streamSecrets = [];
         for (let i = 0; i < streamKeysArray.length; i++) {
@@ -236,10 +245,19 @@ export async function getStreamSecrets(streamKeys) {
  */
 export async function resetStreamSecrets(streamKeys) {
     console.group('STUB: resetStreamSecrets()');
+
+    const facility = getCurrentFacility();
+    // resetStreamSecrets() requires ALManage access level on the server side -
+    // calling it with lower access returns 403 Forbidden.
+    if (!facility?.canManage()) {
+        console.log('(skipped - requires Manage or Owner access level)');
+        console.groupEnd();
+        return;
+    }
     
     const streamKeysArray = streamKeys.split(',').map(k => k.trim());
 
-    const strmMgr = getCurrentFacility()?.getStreamManager();
+    const strmMgr = facility.getStreamManager();
     if (strmMgr) {
         await strmMgr.resetStreamSecrets(streamKeysArray, true);
         console.log('resetStreamSecrets() called with hardReset=true');
@@ -254,7 +272,16 @@ export async function resetStreamSecrets(streamKeys) {
 export async function getStreamIngestionUrls() {
     console.group('STUB: getStreamIngestionUrls()');
 
-    const strmMgr = getCurrentFacility()?.getStreamManager();
+    const facility = getCurrentFacility();
+    // getStreamIngestionUrl() calls getStreamSecret() internally, which requires
+    // ALManage access level on the server side - calling it with lower access returns 403 Forbidden.
+    if (!facility?.canManage()) {
+        console.log('(skipped - requires Manage or Owner access level)');
+        console.groupEnd();
+        return;
+    }
+
+    const strmMgr = facility.getStreamManager();
     if (strmMgr) {
         const jsonObj = await strmMgr.getAllStreamInfos();
         const ingestUrls = [];
@@ -319,6 +346,83 @@ export async function createStream(streamName) {
     console.groupEnd();
 }
 
+// NOTE: createCalculatedStream is behind a feature flag in Tandem and is not
+// yet generally available. The stub is preserved here for future use.
+//
+// /**
+//  * Create a calculated stream and optionally attach it to a selected element.
+//  *
+//  * A calculated stream is a virtual sensor whose values come from programmatic
+//  * computation rather than a real IoT device pushing data via HTTP ingestion.
+//  * Use cases include derived metrics (averages, deltas, sums across real streams)
+//  * or any value your application computes and wants to surface in Tandem.
+//  *
+//  * Key differences from createStream():
+//  *   - Sets calculationSettings: {} in the stream settings object, signalling
+//  *     to Tandem that data will come from internal calculation, not external push.
+//  *   - Sets offlineTimeout to Never — a calculated stream is never flagged offline.
+//  *   - Does NOT produce an ingestion URL (there is no HTTP endpoint to push to).
+//  *
+//  * Parameters:
+//  *   name             — display name for the new stream
+//  *   modelUrnOfParent — model URN of the host element (optional)
+//  *   dbIdOfParent     — dbId of the host element (optional)
+//  *   tandemCategory   — defaults to TC.Sensors
+//  *
+//  * Returns the dbId of the newly created stream element.
+//  *
+//  * Usage: select an element in the viewer to attach the stream to it, then
+//  * enter a name and click Create. If nothing is selected, the stream is created
+//  * without a host element.
+//  */
+// export async function createCalculatedStream(streamName) {
+//     console.group('STUB: createCalculatedStream()');
+//
+//     const strmMgr = getCurrentFacility()?.getStreamManager();
+//     if (!strmMgr) {
+//         console.warn('No stream manager available');
+//         console.groupEnd();
+//         return;
+//     }
+//
+//     if (!streamName?.trim()) {
+//         console.warn('No stream name provided');
+//         console.groupEnd();
+//         return;
+//     }
+//
+//     let dbIdOfParent = null;
+//     let modelUrnOfParent = null;
+//
+//     const aggrSet = getSingleSelectedItemOptional();
+//     if (aggrSet) {
+//         dbIdOfParent = aggrSet[0].selection[0];
+//         modelUrnOfParent = aggrSet[0].model.urn();
+//         console.log(`Host element selected — dbId: ${dbIdOfParent} | modelUrn: ${modelUrnOfParent}`);
+//     } else {
+//         console.log('No element selected — stream will be created without a host element.');
+//     }
+//
+//     const tandemCategory = Autodesk.Tandem.DtConstants.TC.Sensors;
+//     console.log(`Creating calculated stream: "${streamName.trim()}" | category: ${tandemCategory}`);
+//
+//     const newDbId = await strmMgr.createCalculatedStream(
+//         streamName.trim(),
+//         modelUrnOfParent,
+//         dbIdOfParent,
+//         tandemCategory
+//     );
+//
+//     console.log('Created! New stream dbId:', newDbId);
+//
+//     // Convert dbId → elementKey (stable external ID) for use in REST calls
+//     const [elementKey] = await strmMgr.defaultModel.getElementIdsFromDbIds([newDbId]);
+//     console.log('New stream elementKey:', elementKey);
+//     console.log('NOTE: Use the elementKey (not dbId) for REST API calls and for data ingestion references.');
+//
+//     console.groupEnd();
+// }
+
 /**
  * Delete a stream
  */
@@ -346,6 +450,127 @@ export async function getThresholds() {
         console.log('getThresholds()', await strmMgr.getThresholds());
     }
 
+    console.groupEnd();
+}
+
+/**
+ * Get the timestamp of the most recent data point received from any stream.
+ *
+ * Despite the name, getLatestReading() does NOT return stream values. It
+ * returns a single Unix timestamp (in seconds) representing the most recent
+ * moment any stream in the facility sent data. Internally it tracks the
+ * rolling max timestamp across all readings: Math.max(latest, ts).
+ *
+ * Use this as a heartbeat/health check:
+ *   - null  → no readings have been received yet (cache not populated)
+ *   - a timestamp → streams are alive; this is when the last data arrived
+ *
+ * To get actual stream values, use the existing getLastReadings() stub which
+ * calls strmMgr.getLastReadings(streamIds).
+ */
+export async function getLatestReading() {
+    console.group('STUB: getLatestReading()');
+    console.log('NOTE: Returns the timestamp of the most recent data point from any stream — not the values themselves.');
+
+    const strmMgr = getCurrentFacility()?.getStreamManager();
+    if (!strmMgr) {
+        console.warn('No stream manager available');
+        console.groupEnd();
+        return;
+    }
+
+    const latestTs = await strmMgr.getLatestReading();
+
+    if (latestTs === null || latestTs === undefined) {
+        console.warn('Result: null — no readings have been received yet (stream cache may not be populated).');
+    } else {
+        const date = new Date(latestTs * 1000); // ts is in seconds
+        console.log('Most recent data point received at:');
+        console.log('  Timestamp (s):', latestTs);
+        console.log('  Date/time:    ', date.toISOString());
+        console.log('  Local:        ', date.toString());
+    }
+
+    console.groupEnd();
+}
+
+/**
+ * Get the latest readings for all streams together with their alert states.
+ *
+ * This is the most useful "current state" call for IoT monitoring — it returns
+ * both the live values AND whether each channel is within its threshold bounds,
+ * in a single round-trip.
+ *
+ * Returns a tuple: [lastByDbId, alerts]
+ *
+ *   lastByDbId — Map<dbId, { [attrId]: { ts, val } }>
+ *                Most recent reading per channel, per stream.
+ *
+ *   alerts     — Map<dbId, { [attrId]: { currentState } }>
+ *                Alert state per channel. currentState maps to one of:
+ *                  Normal | Warning | Alert | Offline | NoData
+ *
+ * The optional filter.dbIds array narrows the query to specific streams.
+ * Without it, all streams in the facility are included.
+ */
+export async function getLastReadingsWithAlerts() {
+    console.group('STUB: getLastReadingsWithAlerts()');
+
+    const strmMgr = getCurrentFacility()?.getStreamManager();
+    if (!strmMgr) {
+        console.warn('No stream manager available');
+        console.groupEnd();
+        return;
+    }
+
+    const streamIds = await strmMgr.getStreamIds();
+    if (!streamIds.length) {
+        console.warn('No streams found in this facility');
+        console.groupEnd();
+        return;
+    }
+
+    console.log(`Found ${streamIds.length} stream(s). Fetching readings + alert states...`);
+    const streamKeys = await strmMgr.defaultModel.getElementIdsFromDbIds(streamIds);
+
+    // Pass dbIds in the filter so the readings Map is scoped to our streams.
+    // Without dbIds, the worker returns the full unfiltered byDbId Map.
+    const [lastByDbId, alerts] = await strmMgr.getLastReadingsWithAlerts({ dbIds: streamIds });
+
+    console.log('Raw lastByDbId:', lastByDbId);
+    console.log('Raw alerts:', alerts);
+
+    // Flatten into a table: one row per stream-channel combination
+    const rows = [];
+    for (let i = 0; i < streamIds.length; i++) {
+        const dbId = streamIds[i];
+        const key  = streamKeys[i] ?? '(unknown)';
+        const readingsByAttr = lastByDbId?.get(dbId);
+
+        if (!readingsByAttr || Object.keys(readingsByAttr).length === 0) {
+            rows.push({ streamKey: key, dbId, attrId: '—', value: null, timestamp: null, date: '—', alertState: 'NoData' });
+            continue;
+        }
+
+        for (const [attrId, attrReadings] of Object.entries(readingsByAttr)) {
+            // Each attrReadings is { [ts]: val } — grab the latest entry
+            let ts, val;
+            for (const time in attrReadings) { ts = Number(time); val = attrReadings[time]; }
+
+            const alertState = alerts?.get(dbId)?.[attrId]?.currentState ?? 'Normal';
+            rows.push({
+                streamKey:  key,
+                dbId,
+                attrId,
+                value:      val,
+                timestamp:  ts,
+                date:       ts ? new Date(ts * 1000).toISOString() : '—',
+                alertState
+            });
+        }
+    }
+
+    console.table(rows);
     console.groupEnd();
 }
 

--- a/js/stubs/viewerStubs.js
+++ b/js/stubs/viewerStubs.js
@@ -311,25 +311,7 @@ export async function selectAllVisibleElements() {
 }
 
 /**
- * 10. Get hidden elements by model
- */
-export async function getHiddenElementsByModel() {
-    const facility = getCurrentFacility();
-    if (!facility) {
-        console.warn('No facility loaded');
-        return;
-    }
-
-    console.group('STUB: getHiddenElementsByModel()');
-    
-    const resultObjs = facility.getHiddenElementsByModel();
-    console.log('Hidden Elements', resultObjs);
-    
-    console.groupEnd();
-}
-
-/**
- * 11. Hide model
+ * 10. Hide model
  */
 export async function hideModel() {
     const facility = getCurrentFacility();
@@ -357,7 +339,7 @@ export async function hideModel() {
 }
 
 /**
- * 12. Show model
+ * 11. Show model
  */
 export async function showModel() {
     const facility = getCurrentFacility();
@@ -464,7 +446,7 @@ function exportMesh(aggrSet, useWorldSpace) {
 }
 
 /**
- * 13. Scrape geometry from selected elements
+ * 12. Scrape geometry from selected elements
  */
 export function scrapeGeometry() {
     const aggrSet = getAggregateSelection();
@@ -486,7 +468,7 @@ export function scrapeGeometry() {
 }
 
 /**
- * 14. Set theme color for selection
+ * 13. Set theme color for selection
  */
 export async function setThemeColor() {
     const aggrSet = getAggregateSelection();
@@ -513,7 +495,7 @@ export async function setThemeColor() {
 }
 
 /**
- * 15. Unset theme color for selection
+ * 14. Unset theme color for selection
  */
 export async function unsetThemeColor() {
     const aggrSet = getAggregateSelection();
@@ -548,7 +530,7 @@ function restoreColorThemeForView(facility, view) {
 }
 
 /**
- * 16. Clear all theming from facility
+ * 15. Clear all theming from facility
  */
 export function clearAllTheming() {
     const facility = getCurrentFacility();
@@ -566,7 +548,7 @@ export function clearAllTheming() {
 }
 
 /**
- * 17. Get saved views
+ * 16. Get saved views
  */
 export async function getSavedViews() {
     const facility = getCurrentFacility();
@@ -594,7 +576,7 @@ export async function getSavedViews() {
 }
 
 /**
- * 18. Go to a saved view
+ * 17. Go to a saved view
  */
 export async function gotoSavedView(viewName) {
     const facility = getCurrentFacility();

--- a/js/ui/stubUI.js
+++ b/js/ui/stubUI.js
@@ -851,8 +851,9 @@ export async function renderStubs(container, facility) {
         { label: 'Dump Facility Info', description: 'Display detailed facility information', action: facilityStubs.dumpFacilityInfo },
         { label: 'Dump App Info', description: 'Display DtApp object information', action: facilityStubs.dumpAppInfo },
         { label: 'Dump DT Constants', description: 'Display Tandem SDK constants', action: facilityStubs.dumpDtConstants },
-        { label: 'Load Facility Usage Metrics', description: 'Load facility usage metrics', action: facilityStubs.getFacilityUsageMetrics },
-        { label: 'Facility History', description: 'Get recent facility history (30 days)', action: facilityStubs.getFacilityHistory }
+        { label: 'Get Facility Usage Metrics', description: 'Get facility usage metrics', action: facilityStubs.getFacilityUsageMetrics },
+        { label: 'Facility History', description: 'Get recent facility history (30 days)', action: facilityStubs.getFacilityHistory },
+        { label: 'Trigger Asset Cleanup', description: 'Remove orphaned/ghost assets after model re-upload (irreversible)', action: facilityStubs.triggerAssetCleanup }
     ]);
     container.appendChild(facilityDropdown);
     
@@ -876,14 +877,36 @@ export async function renderStubs(container, facility) {
         { label: 'Isolate Rooms', description: 'Isolate rooms in viewer', action: modelStubs.isolateRooms },
         { label: 'Show Elements In Room', description: 'Show elements in selected room', action: modelStubs.showElementsInRoom },
         { label: 'Get Rooms of Element', description: 'Get rooms for selected element', action: modelStubs.getRoomsOfElement },
-        { label: 'Get Element Uf Class', description: 'Get UfClass for selection', action: modelStubs.getElementUfClass },
-        { label: 'Get Element Custom Class', description: 'Get custom class for selection', action: modelStubs.getElementCustomClass },
+        { label: 'Get Element Classes', description: 'Get ufClass, customClass, tandemCategory for selection', action: modelStubs.getElementClasses },
         { label: 'Get Element Bounds', description: 'Get bounding boxes for selection', action: modelStubs.getElementBounds },
         { label: 'Isolate Tagged Assets', description: 'Isolate tagged assets', action: modelStubs.isolateTaggedAssets },
         { label: 'Isolate Un-Tagged Assets', description: 'Isolate un-tagged assets', action: modelStubs.isolateUnTaggedAssets },
         { label: 'Isolate Classified Assets', description: 'Isolate classified assets', action: modelStubs.isolateClassifiedAssets },
         { label: 'Isolate Un-Classified Assets', description: 'Isolate un-classified assets', action: modelStubs.isolateUnClassifiedAssets },
-        { label: 'Viewer Ids --> Element Ids', description: 'Convert selection to external IDs', action: modelStubs.dbIdsToExternalIds }
+        {
+            label: 'Element Ids --> Viewer Ids',
+            description: 'Locate elements by external ID and isolate them in the viewer',
+            hasInput: true,
+            inputConfig: {
+                fields: [
+                    { id: 'elementKeys', label: 'Element IDs (comma-separated)', placeholder: 'e.g., QUFBQUE...,QUFBQUI...' }
+                ],
+                onExecute: (values) => modelStubs.externalIdsToDbIds(values.elementKeys)
+            }
+        },
+        { label: 'Viewer Ids --> Element Ids', description: 'Convert selection to external IDs', action: modelStubs.dbIdsToExternalIds },
+        { label: 'Query Elements', description: 'Query elements using model.query() with 3 progressive examples', action: modelStubs.queryElements },
+        {
+            label: 'Search Elements',
+            description: 'Free-text search across property values using model.search()',
+            hasInput: true,
+            inputConfig: {
+                fields: [
+                    { id: 'searchText', label: 'Search Text', placeholder: 'e.g., Concrete, AHU-01, Level 2' }
+                ],
+                onExecute: (values) => modelStubs.searchElements(values.searchText)
+            }
+        }
     ]);
     container.appendChild(modelDropdown);
     
@@ -1042,6 +1065,18 @@ export async function renderStubs(container, facility) {
                 onExecute: (values) => streamStubs.createStream(values.streamName)
             }
         },
+        // NOTE: createCalculatedStream is behind a feature flag — uncomment when available.
+        // {
+        //     label: 'Create Calculated Stream',
+        //     description: 'Create a virtual stream fed by computation, not IoT hardware (select element to attach)',
+        //     hasInput: true,
+        //     inputConfig: {
+        //         fields: [
+        //             { id: 'streamName', label: 'Stream Name', placeholder: 'e.g., Computed Avg Temperature' }
+        //         ],
+        //         onExecute: (values) => streamStubs.createCalculatedStream(values.streamName)
+        //     }
+        // },
         {
             label: 'Delete Stream',
             description: 'Delete a stream by ID',
@@ -1054,7 +1089,9 @@ export async function renderStubs(container, facility) {
             }
         },
         { label: 'Get Stream Ingestion URLs', description: 'Get stream ingestion URLs', action: streamStubs.getStreamIngestionUrls },
-        { label: 'Get Thresholds', description: 'Get threshold settings', action: streamStubs.getThresholds }
+        { label: 'Get Thresholds', description: 'Get threshold settings', action: streamStubs.getThresholds },
+        { label: 'Get Latest Reading', description: 'Get most recent value for every stream (no parameters needed)', action: streamStubs.getLatestReading },
+        { label: 'Get Last Readings With Alerts', description: 'Get latest values + alert states (Normal/Warning/Alert/Offline) for all streams', action: streamStubs.getLastReadingsWithAlerts }
     ]);
     container.appendChild(streamDropdown);
     
@@ -1069,7 +1106,6 @@ export async function renderStubs(container, facility) {
         { label: 'Get All Elements', description: 'Get all elements in facility', action: viewerStubs.getAllElements },
         { label: 'Get All Visible Elements', description: 'Get currently visible element IDs', action: viewerStubs.getVisibleDbIds },
         { label: 'Select All Visible Elements', description: 'Select all visible elements', action: viewerStubs.selectAllVisibleElements },
-        { label: 'Get Hidden Elements By Model', description: 'Get hidden elements per model', action: viewerStubs.getHiddenElementsByModel },
         { label: 'Hide Model', description: 'Hide the primary model', action: viewerStubs.hideModel },
         { label: 'Show Model', description: 'Show the primary model', action: viewerStubs.showModel },
         { label: 'Scrape Geometry', description: 'Export geometry as OBJ', action: viewerStubs.scrapeGeometry },


### PR DESCRIPTION
- Bump viewer SDK to 1.0.866 in index.html
- Remove getHiddenElementsByModel stub (deleted from SDK)
- Merge getElementUfClass/getElementCustomClass + new getElementTandemCategory into single getElementClasses() stub with unified console.table
- Fix getRoomsOfElement(): add diagnostics, room count, and explicit warning when no rooms found (previously silent on empty result)
- Add triggerAssetCleanup() stub to facilityStubs (canManage guard included)
- Add getLatestReading() stub — clarified as heartbeat timestamp, not values
- Add getLastReadingsWithAlerts() stub — values + alert states per channel
- Add createCalculatedStream() stub (commented out; behind feature flag)
- Guard getUsers/getSubjects/loadUsageMetrics/getStreamSecret/resetStreamSecrets/ getStreamIngestionUrl/deleteDocument with canManage()/isOwner() checks
- Add externalIdsToDbIds() and dbIdsToExternalIds() stubs with terminology notes
- Add queryElements() and searchElements() stubs for model.query/model.search