### PR TITLE
Add profapi:img-profile:read scope for Profile API v2 migration

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -40,7 +40,7 @@ async function generateCodeChallenge(verifier) {
  */
 export async function login() {
     const env = getEnv();
-    const scope = 'data:read data:write user-profile:read';
+    const scope = 'data:read data:write user-profile:read profapi:img-profile:read';
     const codeVerifier = generateRandomString(64);
     const challenge = await generateCodeChallenge(codeVerifier);
     


### PR DESCRIPTION
APS identity is enforcing granular resource-specific scopes for the User Profile API (v2). Add profapi:img-profile:read since the app accesses the picture field from the userinfo endpoint.
